### PR TITLE
Update to use the correct ports and add missing LATENCY var

### DIFF
--- a/remote-player/receiver-audio.sh
+++ b/remote-player/receiver-audio.sh
@@ -12,14 +12,16 @@ ARTPSINKPORT=8100
 ARTCPSINKPORT=8101
 ARTCPSRCPORT=5105
 
+LATENCY=0
+
 AUDIO_CAPS="application/x-rtp,media=(string)audio,clock-rate=(int)48000,encoding-name=(string)OPUS"
 
 AUDIO_DEC="rtpopusdepay ! opusdec"
 AUDIO_SINK="audioconvert ! audioresample ! autoaudiosink"
 
 gst-launch-1.0 -v rtpbin name=rtpbin buffer-mode=none drop-on-latency=true latency=$LATENCY \
-     udpsrc caps=$AUDIO_CAPS port=$VRTPPORT address=$SRC multicast-iface=$SRCIF ! rtpbin.recv_rtp_sink_0 \
+     udpsrc caps=$AUDIO_CAPS port=$ARTPSINKPORT address=$SRC multicast-iface=$SRCIF ! rtpbin.recv_rtp_sink_0 \
        rtpbin. ! $AUDIO_DEC ! $AUDIO_SINK \
-     udpsrc port=$VRTCPPORT address=$SRC multicast-iface=$SRCIF ! rtpbin.recv_rtcp_sink_0 \
-       rtpbin.send_rtcp_src_0 ! udpsink port=$ARTCPSRCPORT host=$SRC multicast-iface=$SRCIF sync=false async=false 
+     udpsrc port=$ARTCPSRCPORT address=$SRC multicast-iface=$SRCIF ! rtpbin.recv_rtcp_sink_0 \
+       rtpbin.send_rtcp_src_0 ! udpsink port=$ARTCPSINKPORT host=$SRC multicast-iface=$SRCIF sync=false async=false 
 


### PR DESCRIPTION
It looks like the initial push for receive-audio.sh had a few typos. It seems to work as expected for me with these changes but if you could review and confirm.

Thanks.